### PR TITLE
[WFLY-14025] Added tests for cases when default datasource binding is removed from ee subsystem

### DIFF
--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/RemoteCacheContainer.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/RemoteCacheContainer.java
@@ -24,7 +24,6 @@ package org.wildfly.clustering.infinispan.client;
 
 import java.util.function.Function;
 
-import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManagerAdmin;
 import org.infinispan.client.hotrod.event.impl.ClientListenerNotifier;
 import org.infinispan.client.hotrod.jmx.RemoteCacheManagerMXBean;
@@ -57,12 +56,6 @@ public interface RemoteCacheContainer extends org.infinispan.client.hotrod.Remot
      * @return administration utility
      */
     RemoteCacheManagerAdmin administration();
-
-    @Override
-    <K, V> RemoteCache<K, V> getCache();
-
-    @Override
-    <K, V> RemoteCache<K, V> getCache(String cacheName);
 
     /**
      * Registers a factory for creating a near cache for a given cache.

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -1975,7 +1975,7 @@ public class InfinispanSubsystemXMLReader implements XMLElementReader<List<Model
                     }
                 }
                 case PROPERTY: {
-                    if (schema.since(InfinispanSchema.VERSION_11_0) || (this.schema.since(InfinispanSchema.VERSION_9_1) && !this.schema.since(InfinispanSchema.VERSION_10_0))) {
+                    if (this.schema.since(InfinispanSchema.VERSION_11_0) || (this.schema.since(InfinispanSchema.VERSION_9_1) && !this.schema.since(InfinispanSchema.VERSION_10_0))) {
                         ParseUtils.requireSingleAttribute(reader, XMLAttribute.NAME.getLocalName());
                         readElement(reader, operation, RemoteCacheContainerResourceDefinition.Attribute.PROPERTIES);
                         break;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolServiceConfigurator.java
@@ -25,17 +25,17 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
-import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
-import org.infinispan.commons.executors.ThreadPoolExecutorFactory;
 import org.infinispan.commons.util.ProcessorInfo;
 import org.infinispan.configuration.global.ThreadPoolConfiguration;
 import org.infinispan.configuration.global.ThreadPoolConfigurationBuilder;
+import org.infinispan.factories.threads.EnhancedQueueExecutorFactory;
 import org.jboss.as.clustering.context.DefaultThreadFactory;
 import org.jboss.as.clustering.infinispan.DefaultNonBlockingThreadFactory;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
+import org.jboss.threads.management.ManageableThreadPoolExecutorService;
 import org.wildfly.clustering.service.ServiceConfigurator;
 
 /**
@@ -65,13 +65,7 @@ public class ThreadPoolServiceConfigurator extends GlobalComponentServiceConfigu
             minThreads *= availableProcessors;
             maxThreads *= availableProcessors;
         }
-        ThreadPoolExecutorFactory<?> factory = new BlockingThreadPoolExecutorFactory(maxThreads, minThreads, queueLength, keepAliveTime, nonBlocking) {
-            @Override
-            public ExecutorService createExecutor(ThreadFactory factory) {
-                return super.createExecutor(this.createsNonBlockingThreads() ? new DefaultNonBlockingThreadFactory(factory) : new DefaultThreadFactory(factory));
-            }
-        };
-        this.builder.threadPoolFactory(factory);
+        this.builder.threadPoolFactory(nonBlocking ? new NonBlockingThreadPoolExecutorFactory(maxThreads, minThreads, queueLength, keepAliveTime) : new BlockingThreadPoolExecutorFactory(maxThreads, minThreads, queueLength, keepAliveTime));
 
         return this;
     }
@@ -79,6 +73,30 @@ public class ThreadPoolServiceConfigurator extends GlobalComponentServiceConfigu
     @Override
     public ThreadPoolConfiguration get() {
         return this.builder.create();
+    }
+
+    private static class BlockingThreadPoolExecutorFactory extends EnhancedQueueExecutorFactory {
+
+        BlockingThreadPoolExecutorFactory(int maxThreads, int coreThreads, int queueLength, long keepAlive) {
+            super(maxThreads, coreThreads, queueLength, keepAlive);
+        }
+
+        @Override
+        public ManageableThreadPoolExecutorService createExecutor(ThreadFactory factory) {
+            return super.createExecutor(new DefaultThreadFactory(factory));
+        }
+    }
+
+    private static class NonBlockingThreadPoolExecutorFactory extends org.infinispan.factories.threads.NonBlockingThreadPoolExecutorFactory {
+
+        NonBlockingThreadPoolExecutorFactory(int maxThreads, int coreThreads, int queueLength, long keepAlive) {
+            super(maxThreads, coreThreads, queueLength, keepAlive);
+        }
+
+        @Override
+        public ExecutorService createExecutor(ThreadFactory factory) {
+            return super.createExecutor(new DefaultNonBlockingThreadFactory(factory));
+        }
     }
 }
 

--- a/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
@@ -508,6 +508,12 @@ sasl-authentication-factory is used based on the mechanism name. In this
 case, configured will match on JBOSS-LOCAL-USER and DIGEST-MD5. It also
 sets the wildfly.sasl.local-user.default-user to $local.
 
+|applicationSSC| The `applicationSSC` server SSL context can be used
+to automatically generate a self-signed certificate the first time
+the HTTPS interface is accessed. This server SSL context should only
+be used for testing purposes. It should never be used in a production
+environment.
+
 |combined-providers |Is an aggregate provider that aggregates the elytron
 and openssl provider loaders.
 
@@ -602,8 +608,29 @@ and openssl provider loaders.
         }},
         "jdbc-realm" => undefined,
         "kerberos-security-factory" => undefined,
-        "key-manager" => undefined,
-        "key-store" => undefined,
+        "key-manager" => {
+            "applicationKM" => {
+                "algorithm" => undefined,
+                "alias-filter" => undefined,
+                "credential-reference" => {"clear-text" => "password"},
+                "generate-self-signed-certificate-host" => "localhost",
+                "key-store" => "applicationKS",
+                "provider-name" => undefined,
+                "providers" => undefined
+            }
+        }
+        "key-store" => {
+            "applicationKS" => {
+                "alias-filter" => undefined,
+                "credential-reference" => {"clear-text" => "password"},
+                "path" => "application.keystore",
+                "relative-to" => "jboss.server.config.dir",
+                "required" => false,
+                "provider-name" => undefined,
+                "providers" => undefined,
+                "type" => "PKCS12"
+            }
+        },
         "key-store-realm" => undefined,
         "ldap-key-store" => undefined,
         "ldap-realm" => undefined,
@@ -760,7 +787,30 @@ and openssl provider loaders.
                 "trusted-security-domains" => undefined
             }
         },
-        "server-ssl-context" => undefined,
+        "server-ssl-context" => {
+            "applicationSSC" => {
+                "authentication-optional" => false,
+                "cipher-suite-filter" => "DEFAULT",
+                "cipher-suite-names" => undefined,
+                "final-principal-transformer" => undefined,
+                "key-manager" => "applicationKM",
+                "maximum-session-cache-size" => -1,
+                "need-client-auth" => false,
+                "post-realm-principal-transformer" => undefined,
+                "pre-realm-principal-transformer" => undefined,
+                "protocols" => undefined,
+                "provider-name" => undefined,
+                "providers" => undefined,
+                "realm-mapper" => undefined,
+                "security-domain" => undefined,
+                "session-timeout" => -1,
+                "trust-manager" => undefined,
+                "use-cipher-suites-order" => true,
+                "want-client-auth" => false,
+                "wrap" => false,
+                "ssl-session" => undefined
+            }
+        },
         "service-loader-http-server-mechanism-factory" => undefined,
         "service-loader-sasl-server-factory" => undefined,
         "simple-permission-mapper" => {"default-permission-mapper" => {
@@ -811,6 +861,62 @@ Authentication
 /subsystem=undertow/application-security-domain=exampleApplicationDomain:add(http-authentication-factory=example-http-auth)
 ----
 For more information on configuring an http-authentication-factory, see <<configure-an-http-authentication-factory, configure an http-authentication-factory>>
+
+SSL/TLS
+
+Undertow can be configured to make use of the `applicationSSC` server SSL context for *testing purposes*,
+as shown below:
+
+[source,bash]
+----
+batch
+/subsystem=undertow/server=default-server/https-listener=https:undefine-attribute(name=security-realm)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=ssl-context,value=applicationSSC)
+run-batch
+reload
+----
+
+The `applicationSSC` server SSL context references the `applicationKM` key manager:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/key-manager=applicationKM:read-resource()
+{
+    "outcome" => "success",
+    "result" => {
+        "algorithm" => undefined,
+        "alias-filter" => undefined,
+        "credential-reference" => {"clear-text" => "password"},
+        "generate-self-signed-certificate-host" => "localhost",
+        "key-store" => "applicationKS",
+        "provider-name" => undefined,
+        "providers" => undefined
+    }
+}
+----
+
+When the `applicationSSC` server SSL context is used by Undertow, a self-signed certificate will automatically
+be generated the first time the HTTPS interface is accessed if the file that backs the `applicationKS` key store
+doesn't exist. This self-signed certificate will then be persisted to the file that backs the `applicationKS` key
+store. The `generate-self-signed-certificate-host` value, `localhost`, will be used as the Common Name (CN) value
+in the generated self-signed certificate. The following messages will appear in the server log file:
+
+[source]
+----
+13:21:39,197 WARN  [org.wildfly.extension.elytron] (MSC service thread 1-6) WFLYELY01083: KeyStore /wildfly/standalone/configuration/application.keystore not found, it will be auto generated on first use with a self-signed certificate for host localhost
+...
+13:39:57,152 WARN  [org.wildfly.extension.elytron] (default task-1) WFLYELY01084: Generated self-signed certificate at /wildfly/dist/target/wildfly-21.0.0.Beta1-SNAPSHOT/standalone/configuration/application.keystore. Please note that self-signed certificates are not secure and should only be used for testing purposes. Do not use this self-signed certificate in production.
+SHA-1 fingerprint of the generated key is fc:16:cf:bf:de:3a:6d:d6:fe:ec:f9:cd:9d:22:c9:3d:43:d7:e3:57
+SHA-256 fingerprint of the generated key is 38:69:00:4e:39:e2:40:e2:ef:b6:95:58:c6:ba:d0:0f:56:c5:7c:5d:fc:d5:c3:b9:b0:94:80:9c:f5:45:9d:40
+----
+
+*NOTE* To disable the automatic self-signed certificate generation, undefine the `generate-self-signed-certificate-host`
+attribute on the `applicationKM` key manager.
+
+*WARNING* This self-signed certificate is only intended to be used for testing purposes. This self-signed certificate
+should never be used in a production environment. For more information on configuring an `ssl-context`,
+see <<configuring-a-server-sslcontext, Configuring a server SSLContext>>. For more information on how to
+easily obtain a signed certificate using the WildFly CLI, see <<obtain-certificate, Obtain a signed certificate from Let's Encrypt>>.
 
 [[default-elytron-application-domain-configuration]]
 === Default Elytron ApplicationDomain Configuration

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -56,7 +56,7 @@
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.authorization.jakarta-authorization-api>2.0.0</version.jakarta.authorization.jakarta-authorization-api>
         <version.jakarta.batch.jakarta.batch-api>2.0.0</version.jakarta.batch.jakarta.batch-api>
-        <version.jakarta.ejb.jakarta-ejb-api>4.0.0-RC2</version.jakarta.ejb.jakarta-ejb-api>
+        <version.jakarta.ejb.jakarta-ejb-api>4.0.0</version.jakarta.ejb.jakarta-ejb-api>
         <version.jakarta.enterprise>3.0.0</version.jakarta.enterprise>
         <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>2.0.0</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
         <version.jakarta.faces.jakarta-faces-api>3.0.0</version.jakarta.faces.jakarta-faces-api>

--- a/ee-9/feature-pack/pom.xml
+++ b/ee-9/feature-pack/pom.xml
@@ -54,6 +54,7 @@
         <version.com.sun.faces>3.0.0.SP02</version.com.sun.faces>
         <version.com.sun.activation.jakarta.activation>2.0.0</version.com.sun.activation.jakarta.activation>
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
+        <version.jakarta.authentication.jakarta-authentication-api>2.0.0</version.jakarta.authentication.jakarta-authentication-api>
         <version.jakarta.authorization.jakarta-authorization-api>2.0.0</version.jakarta.authorization.jakarta-authorization-api>
         <version.jakarta.batch.jakarta.batch-api>2.0.0</version.jakarta.batch.jakarta.batch-api>
         <version.jakarta.ejb.jakarta-ejb-api>4.0.0-RC2</version.jakarta.ejb.jakarta-ejb-api>
@@ -61,14 +62,13 @@
         <version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>2.0.0</version.jakarta.enterprise.concurrent.jakarta-enterprise.concurrent-api>
         <version.jakarta.faces.jakarta-faces-api>3.0.0</version.jakarta.faces.jakarta-faces-api>
         <version.jakarta.inject.jakarta.inject-api>2.0.0</version.jakarta.inject.jakarta.inject-api>
-        <version.jakarta.interceptor.jakarata-interceptors-api>2.0.0</version.jakarta.interceptor.jakarata-interceptors-api>
+        <version.jakarta.interceptor.jakarta-interceptors-api>2.0.0</version.jakarta.interceptor.jakarta-interceptors-api>
         <version.jakarta.jms.jakarta-jms-api>3.0.0</version.jakarta.jms.jakarta-jms-api>
         <version.jakarta.json.bind.api>2.0.0</version.jakarta.json.bind.api>
         <version.jakarta.json.jakarta-json-api>2.0.0</version.jakarta.json.jakarta-json-api>
         <version.jakarta.mail>2.0.0</version.jakarta.mail>
         <version.jakarta.persistence>3.0.0</version.jakarta.persistence>
         <version.jakarta.resource.jakarta-resource-api>2.0.0</version.jakarta.resource.jakarta-resource-api>
-        <version.jakarta.security.auth.message.jakarta-security-auth-message-api>2.0.0-RC1</version.jakarta.security.auth.message.jakarta-security-auth-message-api>
         <version.jakarta.security.enterprise>2.0.0</version.jakarta.security.enterprise>
         <version.jakarta.servlet.jakarta-servlet-api>5.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>3.0.0</version.jakarta.servlet.jsp.jakarta-servlet-jsp-api>
@@ -378,7 +378,7 @@
         <dependency>
             <groupId>jakarta.interceptor</groupId>
             <artifactId>jakarta.interceptor-api</artifactId>
-            <version>${version.jakarta.interceptor.jakarata-interceptors-api}</version>
+            <version>${version.jakarta.interceptor.jakarta-interceptors-api}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -394,9 +394,9 @@
             <scope>provided</scope>
         </dependency>-->
         <dependency>
-            <groupId>jakarta.security.auth.message</groupId>
-            <artifactId>jakarta.security.auth.message-api</artifactId>
-            <version>${version.jakarta.security.auth.message.jakarta-security-auth-message-api}</version>
+            <groupId>jakarta.authentication</groupId>
+            <artifactId>jakarta.authentication-api</artifactId>
+            <version>${version.jakarta.authentication.jakarta-authentication-api}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/ee-9/feature-pack/src/license/feature-pack-licenses.xml
+++ b/ee-9/feature-pack/src/license/feature-pack-licenses.xml
@@ -29,6 +29,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>jakarta.authentication</groupId>
+      <artifactId>jakarta.authentication-api</artifactId>
+      <licenses>
+        <license>
+          <name>Eclipse Public License 2.0</name>
+          <url>http://www.eclipse.org/legal/epl-v20.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <licenses>

--- a/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/auth/message/api/main/module.xml
+++ b/ee-9/feature-pack/src/main/resources/modules/system/layers/base/jakarta/security/auth/message/api/main/module.xml
@@ -31,6 +31,6 @@
 
     <resources>
         <!--<artifact name="${org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.1_spec}"/>-->
-        <artifact name="${jakarta.security.auth.message:jakarta.security.auth.message-api}"/>
+        <artifact name="${jakarta.authentication:jakarta.authentication-api}"/>
     </resources>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
@@ -24,6 +24,10 @@
 
 <module xmlns="urn:jboss:module:1.5" name="org.jboss.narayana.compensations">
 
+    <properties>
+        <property name="jboss.api" value="deprecated"/>
+    </properties>
+
     <resources>
         <artifact name="${org.jboss.narayana.compensations:compensations}"/>
     </resources>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -24,6 +24,10 @@
 
 <module xmlns="urn:jboss:module:1.5" name="org.jboss.xts">
 
+    <properties>
+        <property name="jboss.api" value="deprecated"/>
+    </properties>
+
     <resources>
         <artifact name="${org.jboss.narayana.xts:jbossxts}"/>
         <artifact name="${org.jboss.narayana:jbosstxbridge}"/>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -8,7 +8,7 @@
     </dependencies>
 
     <feature spec="subsystem.ejb3">
-        <param name="default-stateful-bean-access-timeout" value="3000"/>
+        <param name="default-stateful-bean-access-timeout" value="5000"/>
         <param name="default-sfsb-cache" value="distributable"/>
     </feature>
 

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
@@ -4,7 +4,7 @@
         <layer name="transactions"/>
     </dependencies>
     <feature spec="subsystem.ejb3">
-        <param name="default-stateful-bean-access-timeout" value="3000"/>
+        <param name="default-stateful-bean-access-timeout" value="5000"/>
         <param name="default-sfsb-cache" value="simple"/>
     </feature>
     <!-- Infinispan cache configuration used for local SFSB caching -->

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
@@ -64,15 +64,21 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
         final DeploymentUnit tl = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+        //Set default when no default version has been set on the war file
+        String jsfVersion = JsfVersionMarker.getVersion(tl).equals(JsfVersionMarker.NONE)? JSFModuleIdFactory.getInstance().getDefaultSlot() : JsfVersionMarker.getVersion(tl);
+        String defaultJsfVersion = JSFModuleIdFactory.getInstance().getDefaultSlot();
+
         if(JsfVersionMarker.isJsfDisabled(deploymentUnit)) {
+            if (jsfVersion.equals(defaultJsfVersion) && !moduleIdFactory.isValidJSFSlot(jsfVersion)) {
+                throw JSFLogger.ROOT_LOGGER.invalidDefaultJSFImpl(defaultJsfVersion);
+            }
             addJSFAPI(JsfVersionMarker.JSF_2_0, moduleSpecification, moduleLoader);
             return;
         }
         if (!DeploymentTypeMarker.isType(DeploymentType.WAR, deploymentUnit) && !DeploymentTypeMarker.isType(DeploymentType.EAR, deploymentUnit)) {
             return;
         }
-        //Set default when no default version has been set on the war file
-        String jsfVersion = JsfVersionMarker.getVersion(tl).equals(JsfVersionMarker.NONE)? JSFModuleIdFactory.getInstance().getDefaultSlot() : JsfVersionMarker.getVersion(tl);
+
         if (jsfVersion.equals(JsfVersionMarker.WAR_BUNDLES_JSF_IMPL)) {
             //if JSF is provided by the application we leave it alone
             return;
@@ -80,7 +86,7 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
         //TODO: we should do that same check that is done in com.sun.faces.config.FacesInitializer
         //and only add the dependency if JSF is actually needed
 
-        String defaultJsfVersion = JSFModuleIdFactory.getInstance().getDefaultSlot();
+
         if (!moduleIdFactory.isValidJSFSlot(jsfVersion)) {
             JSFLogger.ROOT_LOGGER.unknownJSFVersion(jsfVersion, defaultJsfVersion);
             jsfVersion = defaultJsfVersion;

--- a/microprofile/galleon-common/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/microprofile/galleon-common/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
+    <dependencies>
+        <layer name="microprofile-config" optional="true"/>
+        <layer name="microprofile-metrics" optional="true"/>
+        <layer name="open-tracing" optional="true"/>
+        <layer name="microprofile-health" optional="true"/>
+    </dependencies>
+</layer-spec>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
         <version.org.jboss.ws.spi>3.3.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
-        <version.org.jgroups>4.2.9.Final</version.org.jgroups>
+        <version.org.jgroups>4.2.10.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.3.0.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.15.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>

--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>
-        <version.org.jboss.hal.console>3.2.11.Final</version.org.jboss.hal.console>
+        <version.org.jboss.hal.console>3.2.12.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.4.25.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>

--- a/pom.xml
+++ b/pom.xml
@@ -458,7 +458,6 @@
         <!-- Apache xml-resolver -->
         <version.xom>1.2.10</version.xom>
 
-
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>5.0.0.Beta2</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>5.0.0.Beta3</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.2.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.verifier.plugin>1.1</version.verifier.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.36.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.37.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <version.com.squareup.okhttp3>3.9.0</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.1</version.com.sun.activation.jakarta.activation>
-        <version.com.sun.faces>2.3.14.SP01</version.com.sun.faces>
+        <version.com.sun.faces>2.3.14.SP02</version.com.sun.faces>
         <version.com.sun.istack>3.0.10</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.13</version.com.sun.xml.fastinfoset>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>14.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>14.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,6 @@
         <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bitbucket.jose4j>0.7.0</version.org.bitbucket.jose4j>
-        <version.org.bouncycastle>1.65</version.org.bouncycastle>
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00007</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
@@ -5645,24 +5644,6 @@
                         <artifactId>jakarta.xml.bind-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcmail-jdk15on</artifactId>
-                <version>${version.org.bouncycastle}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${version.org.bouncycastle}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${version.org.bouncycastle}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
         <version.org.hibernate.validator>6.0.21.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <!-- n.b. Infinispan Server version used for integration testing is defined separately in testsuite/integration/clustering/pom.xml -->
-        <version.org.infinispan>11.0.5.Final</version.org.infinispan>
+        <version.org.infinispan>11.0.7.Final</version.org.infinispan>
         <version.org.infinispan.protostream>4.3.4.Final</version.org.infinispan.protostream>
         <version.org.jasypt>1.9.3</version.org.jasypt>
         <version.org.javassist>3.23.2-GA</version.org.javassist>

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
         <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.4</version.io.smallrye.smallrye-metrics>
-        <version.io.smallrye.open-api>2.0.14</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.0.15</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.9.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <version.io.reactivex.rxjava3>3.0.4</version.io.reactivex.rxjava3>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
         <version.io.smallrye.smallrye-config>1.6.2</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-fault-tolerance>4.3.1</version.io.smallrye.smallrye-fault-tolerance>
+        <version.io.smallrye.smallrye-fault-tolerance>4.3.2</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.4</version.io.smallrye.smallrye-metrics>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -412,6 +412,11 @@
             <artifactId>wildfly-jaxrs</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-jsf</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- To be able to start a 'remote' broker -->
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSServlet.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.junit.Assert;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This can be used only in tests which remove default datasource binding from ee subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+@WebServlet(name = "DefaultDSServlet", urlPatterns = {"/defaultDS"}, loadOnStartup = 1)
+public class DefaultDSServlet extends HttpServlet {
+
+    @Resource()
+    private DataSource dataSource;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter out = resp.getWriter();
+        // this is expected to be null because default datasource binding was removed from ee subsystem
+        Assert.assertNull(dataSource);
+        try {
+            new InitialContext().lookup("java:comp/env/dataSource");
+            Assert.fail("Lookup should fail!");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NamingException);
+        }
+        out.print("OK");
+        out.flush();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithCtxListenerServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithCtxListenerServlet.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.junit.Assert;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebListener;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This can be used only in tests which remove default datasource binding from ee subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+@WebServlet(name = "DefaultDSWithCtxListenerServlet", urlPatterns = {"/defaultDSWithCtxListener"}, loadOnStartup = 1)
+public class DefaultDSWithCtxListenerServlet extends HttpServlet {
+
+    @Resource(name = "ds")
+    private DataSource dataSource;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter out = resp.getWriter();
+        // this is expected to be null because default datasource binding was removed from ee subsystem
+        Assert.assertNull(dataSource);
+        // the ds injection can be done in a ServeltContextListener just like what spring does
+        Assert.assertNotNull(getServletContext().getAttribute("lookupDS"));
+        // but it looks like java:comp/env/ds does not work
+        try {
+            new InitialContext().lookup("java:comp/env/ds");
+            Assert.fail("java:comp/env/ds should not be available ??");
+        } catch (NamingException e) {
+            Assert.assertTrue(e.getMessage().contains("env/ds"));
+        }
+        out.print("OK");
+        out.flush();
+    }
+
+    // this simulates spring context which does resource injection.
+    @WebListener
+    public static class CtxListener implements ServletContextListener {
+        @Override
+        public void contextInitialized(ServletContextEvent sce) {
+            try {
+                Object obj = new InitialContext().lookup("java:jboss/datasources/ExampleDS");
+                sce.getServletContext().setAttribute("lookupDS", obj);
+            } catch (NamingException e) {
+                Assert.fail(e.getMessage());
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithNameServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDSWithNameServlet.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.junit.Assert;
+
+import javax.annotation.Resource;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * This can be used only in tests which remove default datasource binding from ee subsystem.
+ *
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+public class DefaultDSWithNameServlet extends HttpServlet {
+
+    private boolean hasLookup;
+
+    @Resource(name = "ds")
+    private DataSource dataSource;
+
+    @Override
+    public void init() throws ServletException {
+        try {
+            hasLookup = Boolean.parseBoolean(getServletConfig().getInitParameter("hasLookup"));
+        } catch (Exception e) {
+            hasLookup = false;
+        }
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter out = resp.getWriter();
+        if (hasLookup) {
+            if (dataSource == null) {
+                throw new ServletException("dataSource is null when lookup is defined in jboss-web.xml");
+            }
+        } else {
+            if (dataSource != null) {
+                throw new ServletException("No lookup is defined, dataSource should be null");
+            }
+        }
+
+        if (hasLookup) {
+            try {
+                Assert.assertNotNull(new InitialContext().lookup("java:comp/env/ds"));
+            } catch (NamingException e) {
+                throw new IOException("Cannot lookup java:comp/env/ds when has lookup specified", e);
+            }
+        } else {
+            try {
+                new InitialContext().lookup("java:comp/env/ds");
+                Assert.fail("lookup should fail when no lookup specified for 'java:comp/env/ds'");
+            } catch (NamingException e) {
+                Assert.assertTrue(e.getMessage().contains("env/ds"));
+            }
+        }
+        out.print("OK");
+        out.flush();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDataSourceRemovedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/naming/defaultbindings/datasource/DefaultDataSourceRemovedTestCase.java
@@ -1,0 +1,163 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.naming.defaultbindings.datasource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.ee.subsystem.DefaultBindingsResourceDefinition;
+import org.jboss.as.ee.subsystem.EESubsystemModel;
+import org.jboss.as.ee.subsystem.EeExtension;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.jaxrs.packaging.war.WebXml;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+/**
+ * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(DefaultDataSourceRemovedTestCase.RemoveDefaultDSBindingSetupTask.class)
+public class DefaultDataSourceRemovedTestCase {
+
+    static class RemoveDefaultDSBindingSetupTask extends SnapshotRestoreSetupTask {
+        @Override
+        protected void doSetup(ManagementClient client, String containerId) throws Exception {
+            ModelNode undefineDatasourceFromDefaultBindings = new ModelNode();
+            undefineDatasourceFromDefaultBindings.get(ModelDescriptionConstants.ADDRESS)
+                    .set(PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM,EeExtension.SUBSYSTEM_NAME), EESubsystemModel.DEFAULT_BINDINGS_PATH).toModelNode());
+            undefineDatasourceFromDefaultBindings.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION);
+            undefineDatasourceFromDefaultBindings.get(ModelDescriptionConstants.NAME).set(DefaultBindingsResourceDefinition.DATASOURCE);
+            ModelNode response = client.getControllerClient().execute(undefineDatasourceFromDefaultBindings);
+            Assert.assertEquals(SUCCESS, response.get(OUTCOME).asString());
+        }
+    }
+
+    @Deployment(name = "with-default-ds")
+    public static WebArchive defaultDS() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds.war");
+        war.addClasses(DefaultDSServlet.class);
+        war.addPackage(HttpRequest.class.getPackage());
+        return war;
+    }
+
+    @Deployment(name = "with-default-ds-with-name")
+    public static WebArchive defaultDSWithName() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds-with-name.war");
+        war.addPackage(HttpRequest.class.getPackage());
+        war.addClasses(DefaultDSWithNameServlet.class);
+        war.addAsWebInfResource(WebXml.get("<servlet>\n" +
+                "  <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "  <servlet-class>org.jboss.as.test.integration.ee.naming.defaultbindings.datasource.DefaultDSWithNameServlet</servlet-class>" +
+                "  <load-on-startup>1</load-on-startup>\n" +
+                "</servlet>\n" +
+                "<servlet-mapping>\n" +
+                "    <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "    <url-pattern>/defaultDSWithName</url-pattern>\n" +
+                "</servlet-mapping>"), "web.xml");
+        return war;
+    }
+
+    @Deployment(name = "with-default-ds-with-name-and-lookup")
+    public static WebArchive defaultDSWithNameAndLookup() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds-with-name-and-lookup.war");
+        war.addClasses(DefaultDSWithNameServlet.class);
+        war.addPackage(HttpRequest.class.getPackage());
+        war.addAsWebInfResource(WebXml.get("<servlet>\n" +
+                "  <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "  <servlet-class>org.jboss.as.test.integration.ee.naming.defaultbindings.datasource.DefaultDSWithNameServlet</servlet-class>\n" +
+                "  <load-on-startup>1</load-on-startup>\n" +
+                "    <init-param>\n" +
+                "      <param-name>hasLookup</param-name>\n" +
+                "      <param-value>true</param-value>\n" +
+                "    </init-param>\n" +
+                "</servlet>\n" +
+                "<servlet-mapping>\n" +
+                "    <servlet-name>DefaultDSWithNameServlet</servlet-name>\n" +
+                "    <url-pattern>/defaultDSWithName</url-pattern>\n" +
+                "</servlet-mapping>"), "web.xml");
+        war.addAsWebInfResource(new StringAsset("<jboss-web>\n" +
+                "    <resource-ref>\n" +
+                "        <res-ref-name>ds</res-ref-name>\n" +
+                "        <res-type>javax.sql.DataSource</res-type>\n" +
+                "        <lookup-name>java:jboss/datasources/ExampleDS</lookup-name>\n" +
+                "    </resource-ref>\n" +
+                "</jboss-web>"), "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = "with-default-ds-with-name-and-ctx")
+    public static WebArchive defaultDSWithNameAndCtx() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "with-default-ds-with-name-and-ctx.war");
+        war.addClasses(DefaultDSWithCtxListenerServlet.class);
+        war.addPackage(HttpRequest.class.getPackage());
+        return war;
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds")
+    public void testDeployDefaultDS(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDS", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds-with-name")
+    public void testDeployDefaultDSWithName(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDSWithName", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds-with-name-and-lookup")
+    public void testDeployDefaultDSWithNameAndLookup(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDSWithName", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+    @Test
+    @OperateOnDeployment("with-default-ds-with-name-and-ctx")
+    public void testDeployDefaultDSWithNameAndCtx(@ArquillianResource URL webURL) throws Exception {
+        String response = HttpRequest.get(webURL + "/defaultDSWithCtxListener", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("OK", response);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/deployment/NonExistingJsfImplDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/deployment/NonExistingJsfImplDeploymentTestCase.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jsf.deployment;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.jsf.logging.JSFLogger;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(NonExistingJsfImplDeploymentTestCase.SetupTask.class)
+public class NonExistingJsfImplDeploymentTestCase {
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(testable = false, managed = false, name = "test_jar")
+    public static Archive<?> deploy() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+        archive.addClass(NonExistingJsfImplDeploymentTestCase.class);
+        return archive;
+    }
+
+    private static final PathAddress JSF_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, "jsf");
+
+    @Test
+    public void testDeploymentDoesntFailBecauseOfNPE() throws Exception {
+        try {
+            deployer.deploy("test_jar");
+            Assert.fail("Expected DeploymentException not thrown");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof DeploymentException);
+            Assert.assertTrue(e.getMessage().contains(JSFLogger.ROOT_LOGGER.invalidDefaultJSFImpl("idontexist").getMessage()));
+        }
+    }
+
+    static class SetupTask extends SnapshotRestoreSetupTask {
+        @Override
+        protected void doSetup(ManagementClient client, String containerId) throws Exception {
+            ModelControllerClient mcc = client.getControllerClient();
+            ModelNode writeJSFAttributeOperation = Operations.createWriteAttributeOperation(JSF_ADDRESS.toModelNode(), "default-jsf-impl-slot", "idontexist");
+            ModelNode response = mcc.execute(writeJSFAttributeOperation);
+            Assert.assertEquals(SUCCESS, response.get(OUTCOME).asString());
+            ServerReload.executeReloadAndWaitForCompletion(client);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -39,7 +39,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -48,7 +47,6 @@ import org.junit.runner.RunWith;
  *
  * @author jdenise@redhat.com
  */
-@Ignore("WFLY-14145")
 @RunWith(Arquillian.class)
 public class SecurityCommandsTestCase {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -39,6 +39,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -47,6 +48,7 @@ import org.junit.runner.RunWith;
  *
  * @author jdenise@redhat.com
  */
+@Ignore("WFLY-14145")
 @RunWith(Arquillian.class)
 public class SecurityCommandsTestCase {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -53,6 +53,13 @@ import org.junit.runner.RunWith;
 public class SecurityCommandsTestCase {
 
     private static final String DEFAULT_SERVER = "default-server";
+    private static final String DEFAULT_KEY_STORE = "applicationKS";
+    private static final String DEFAULT_KEY_MANAGER = "applicationKM";
+    private static final String DEFAULT_SSL_CONTEXT = "applicationSSC";
+    private static final int DEFAULT_NUM_KEY_STORES = 1;
+    private static final int DEFAULT_NUM_KEY_MANAGERS = 1;
+    private static final int DEFAULT_NUM_TRUST_MANAGERS = 0;
+    private static final int DEFAULT_NUM_SSL_CONTEXTS = 1;
     private static final ByteArrayOutputStream consoleOutput = new ByteArrayOutputStream();
 
     private static CommandContext ctx;
@@ -566,17 +573,17 @@ public class SecurityCommandsTestCase {
 
         // A new key-store
         List<String> ks = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
-        Assert.assertEquals(1, ks.size());
+        Assert.assertEquals(DEFAULT_NUM_KEY_STORES + 1, ks.size());
         // A new keyManager
         List<String> km = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
-        Assert.assertEquals(1, km.size());
+        Assert.assertEquals(DEFAULT_NUM_KEY_MANAGERS + 1, km.size());
         // A new SSLContext
         List<String> sslCtx = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
-        Assert.assertEquals(1, sslCtx.size());
+        Assert.assertEquals(DEFAULT_NUM_SSL_CONTEXTS + 1, sslCtx.size());
         // Http-interface is secured.
         String usedSslCtx = getSSLContextName(ctx, serverName);
         Assert.assertNotNull(usedSslCtx);
-        Assert.assertEquals(sslCtx.get(0), usedSslCtx);
+        Assert.assertTrue(sslCtx.contains(usedSslCtx));
 
         // Disable ssl, resources shouldn't be deleted
         ctx.handle("security disable-ssl-http-server --no-reload"
@@ -620,7 +627,7 @@ public class SecurityCommandsTestCase {
         ctx.handle("security disable-ssl-http-server --no-reload" + (serverName == null ? "" : " --server-name=" + serverName));
 
         // Enable SSL with key-store-name, no new resources created.
-        ctx.handle("security enable-ssl-http-server --key-store-name=" + ks.get(0)
+        ctx.handle("security enable-ssl-http-server --key-store-name=" + ks.get(1)
                 + " --no-reload" + (serverName == null ? "" : " --server-name=" + serverName));
         String usedSslCtx4 = getSSLContextName(ctx, serverName);
         Assert.assertNotNull(usedSslCtx4);
@@ -644,13 +651,13 @@ public class SecurityCommandsTestCase {
         String usedSslCtx5 = getSSLContextName(ctx, serverName);
         Assert.assertEquals(SSL_CONTEXT_NAME, usedSslCtx5);
         List<String> ks5 = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
-        Assert.assertEquals(2, ks5.size());
+        Assert.assertEquals(DEFAULT_NUM_KEY_STORES + 2, ks5.size());
         Assert.assertTrue(ks5.contains(KEY_STORE_NAME));
         List<String> km5 = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
-        Assert.assertEquals(2, km5.size());
+        Assert.assertEquals(DEFAULT_NUM_KEY_MANAGERS + 2, km5.size());
         Assert.assertTrue(km5.contains(KEY_MANAGER_NAME));
         List<String> sslCtx5 = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
-        Assert.assertEquals(2, sslCtx5.size());
+        Assert.assertEquals(DEFAULT_NUM_SSL_CONTEXTS + 2, sslCtx5.size());
         Assert.assertTrue(sslCtx5.contains(SSL_CONTEXT_NAME));
 
         checkModel(serverName, SERVER_KEY_STORE_FILE, Util.JBOSS_SERVER_CONFIG_DIR,
@@ -765,8 +772,8 @@ public class SecurityCommandsTestCase {
             ModelNode trustManager = getResource(Util.TRUST_MANAGER, tmList.get(0), null);
             checkModel(mgmtInterface, GENERATED_KEY_STORE_FILE_NAME, Util.JBOSS_SERVER_CONFIG_DIR,
                     GENERATED_KEY_STORE_PASSWORD, GENERATED_TRUST_STORE_FILE_NAME,
-                    GENERATED_KEY_STORE_PASSWORD, ksList.get(0), kmList.get(0),
-                    trustManager.get(Util.KEY_STORE).asString(), tmList.get(0), sslContextList.get(0));
+                    GENERATED_KEY_STORE_PASSWORD, ksList.get(1), kmList.get(1),
+                    trustManager.get(Util.KEY_STORE).asString(), tmList.get(0), sslContextList.get(1));
 
             ctx.handle("security disable-ssl-http-server --no-reload"
                     + (mgmtInterface == null ? "" : " --server-name=" + mgmtInterface));
@@ -870,11 +877,15 @@ public class SecurityCommandsTestCase {
     private static void removeTLS() throws CommandLineException {
         List<String> sslContextList = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
         for (String ssl : sslContextList) {
-            ctx.handle("/subsystem=elytron/server-ssl-context=" + ssl + ":remove");
+            if (! ssl.equals(DEFAULT_SSL_CONTEXT)) {
+                ctx.handle("/subsystem=elytron/server-ssl-context=" + ssl + ":remove");
+            }
         }
         List<String> kmList = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
         for (String km : kmList) {
-            ctx.handle("/subsystem=elytron/key-manager=" + km + ":remove");
+            if (! km.equals(DEFAULT_KEY_MANAGER)) {
+                ctx.handle("/subsystem=elytron/key-manager=" + km + ":remove");
+            }
         }
         List<String> tmList = getNames(ctx.getModelControllerClient(), Util.TRUST_MANAGER);
         for (String tm : tmList) {
@@ -882,7 +893,9 @@ public class SecurityCommandsTestCase {
         }
         List<String> ksList = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
         for (String ks : ksList) {
-            ctx.handle("/subsystem=elytron/key-store=" + ks + ":remove");
+            if (! ks.equals(DEFAULT_KEY_STORE)) {
+                ctx.handle("/subsystem=elytron/key-store=" + ks + ":remove");
+            }
         }
         List<String> credentialStoreList = getNames(ctx.getModelControllerClient(), "credential-store");
         for (String cs : credentialStoreList) {
@@ -898,13 +911,13 @@ public class SecurityCommandsTestCase {
 
     private static void assertTLSNumResources(int numKS, int numKeyManager, int numTrustManager, int numSSLContext) throws Exception {
         List<String> ks = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
-        Assert.assertEquals(numKS, ks.size());
+        Assert.assertEquals(DEFAULT_NUM_KEY_STORES + numKS, ks.size());
         List<String> km = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
-        Assert.assertEquals(numKeyManager, km.size());
+        Assert.assertEquals(DEFAULT_NUM_KEY_MANAGERS + numKeyManager, km.size());
         List<String> tm = getNames(ctx.getModelControllerClient(), Util.TRUST_MANAGER);
-        Assert.assertEquals(numTrustManager, tm.size());
+        Assert.assertEquals(DEFAULT_NUM_TRUST_MANAGERS + numTrustManager, tm.size());
         List<String> sslCtx = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
-        Assert.assertEquals(numSSLContext, sslCtx.size());
+        Assert.assertEquals(DEFAULT_NUM_SSL_CONTEXTS + numSSLContext, sslCtx.size());
     }
 
     private static void assertTLSEmpty() throws Exception {

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -45,7 +45,7 @@
         <surefire.forked.process.timeout>5400</surefire.forked.process.timeout>
         <test-group>org/jboss/as/test/clustering/cluster</test-group>
         <version.org.jboss.byteman>4.0.6</version.org.jboss.byteman>
-        <version.org.infinispan.server>11.0.4.Final</version.org.infinispan.server>
+        <version.org.infinispan.server>11.0.7.Final</version.org.infinispan.server>
         <ts.surefire.clustering.ha.additionalExcludes>nothing-by-default</ts.surefire.clustering.ha.additionalExcludes>
     </properties>
 

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -143,21 +143,18 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk15on</artifactId>
-            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>${version.org.bouncycastle}</version>
             <scope>test</scope>
         </dependency>
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/AutomaticSelfSignedCertificateGenerationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/AutomaticSelfSignedCertificateGenerationTestCase.java
@@ -1,0 +1,227 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.ssl;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.jboss.as.test.integration.security.common.SSLTruststoreUtil.HTTPS_PORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.codehaus.plexus.util.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.SSLTruststoreUtil;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.Path;
+import org.wildfly.test.security.common.elytron.SimpleKeyManager;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.UndertowSslContext;
+
+/**
+ * Tests for the automatic creation of a lazily generated self-signed certificate when Elytron
+ * is in use.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ AutomaticSelfSignedCertificateGenerationTestCase.ElytronAndUndertowSetupTask.class })
+@RunAsClient
+@Category(CommonCriteria.class)
+public class AutomaticSelfSignedCertificateGenerationTestCase {
+
+    private static final String NAME = AutomaticSelfSignedCertificateGenerationTestCase.class.getSimpleName();
+    private static final File WORK_DIR = new File("target" + File.separatorChar +  NAME);
+    private static final File SERVER_KEYSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.SERVER_KEYSTORE);
+    private static final File CLIENT_TRUSTSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.CLIENT_TRUSTSTORE);
+    private static final String PASSWORD = SecurityTestConstants.KEYSTORE_PASSWORD;
+    private static final String GENERATE_SELF_SIGNED_CERTIFICATE_HOST="customHostName";
+    private static final String SERVER_ALIAS = "server";
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war").addClasses(SimpleServlet.class);
+    }
+
+    @Test
+    public void testSelfSignedCertificateGenerated() throws Exception {
+        final URL servletUrl = new URL("https", TestSuiteEnvironment.getServerAddress(), HTTPS_PORT,
+                "/" + NAME + "/" + SimpleServlet.SERVLET_PATH.substring(1));
+        HttpClient client = SSLTruststoreUtil.getHttpClientWithSSL(null, null);
+        try {
+            assertFalse(SERVER_KEYSTORE_FILE.exists()); // keystore doesn't exist initially
+            try {
+                // attempt to access the https interface
+                Utils.makeCallWithHttpClient(servletUrl, client, SC_OK);
+            } catch (SSLHandshakeException expected) {
+            }
+            // keystore should now exist and should contain a self-signed certificate
+            assertTrue(SERVER_KEYSTORE_FILE.exists());
+            X509Certificate serverCert;
+            try (FileInputStream is = new FileInputStream(SERVER_KEYSTORE_FILE.getAbsolutePath())) {
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                keyStore.load(is, PASSWORD.toCharArray());
+                assertEquals(1, keyStore.size());
+                serverCert = (X509Certificate) keyStore.getCertificate(SERVER_ALIAS);
+                assertEquals(serverCert.getSubjectX500Principal(), serverCert.getIssuerX500Principal());
+                assertEquals("CN=" + GENERATE_SELF_SIGNED_CERTIFICATE_HOST, serverCert.getSubjectX500Principal().getName());
+            }
+
+            // add the server's newly generated certificate to the client's truststore
+            try (FileOutputStream fos = new FileOutputStream(CLIENT_TRUSTSTORE_FILE)) {
+                KeyStore trustStore = KeyStore.getInstance("PKCS12");
+                trustStore.load(null, null);
+                trustStore.setCertificateEntry("server", serverCert);
+                trustStore.store(fos, PASSWORD.toCharArray());
+            }
+
+            try {
+                // attempt to access the https interface again
+                client = SSLTruststoreUtil.getHttpClientWithSSL(CLIENT_TRUSTSTORE_FILE, PASSWORD);
+                Utils.makeCallWithHttpClient(servletUrl, client, SC_OK);
+            } catch (IOException | URISyntaxException ex) {
+                throw new IllegalStateException("Unable to request server root over HTTPS", ex);
+            } finally {
+                if (CLIENT_TRUSTSTORE_FILE.exists()) {
+                    CLIENT_TRUSTSTORE_FILE.delete();
+                }
+            }
+
+            try (FileInputStream is = new FileInputStream(SERVER_KEYSTORE_FILE.getAbsolutePath())) {
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                keyStore.load(is, PASSWORD.toCharArray());
+                assertEquals(1, keyStore.size());
+                assertEquals(serverCert, keyStore.getCertificate(SERVER_ALIAS)); // server's certificate should be unchanged
+            }
+        } finally {
+            closeClient(client);
+        }
+    }
+
+    @Test
+    public void testSelfSignedCertificateNotGeneratedIfGenerateAttributeUndefined() throws Exception {
+        // undefine generate-self-signed-certificate-host
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:undefine-attribute(name=generate-self-signed-certificate-host)",
+                    NAME));
+            cli.sendLine(String.format("reload"));
+        }
+        try {
+            final URL servletUrl = new URL("https", TestSuiteEnvironment.getServerAddress(), HTTPS_PORT,
+                    "/" + NAME + "/" + SimpleServlet.SERVLET_PATH.substring(1));
+            HttpClient client = SSLTruststoreUtil.getHttpClientWithSSL(null, null);
+            assertFalse(SERVER_KEYSTORE_FILE.exists()); // keystore doesn't exist
+            try {
+                // attempt to access the https interface
+                Utils.makeCallWithHttpClient(servletUrl, client, SC_OK);
+                fail("Expected SSLHandshakeException not thrown");
+            } catch (SSLHandshakeException expected) {
+            }
+            assertFalse(SERVER_KEYSTORE_FILE.exists()); // keystore wasn't created
+        } finally {
+            // clean up
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:write-attribute(name=generate-self-signed-certificate-host,value=%s)",
+                        NAME, GENERATE_SELF_SIGNED_CERTIFICATE_HOST));
+                cli.sendLine(String.format("reload"));
+            }
+        }
+    }
+
+    static class ElytronAndUndertowSetupTask extends AbstractElytronSetupTask {
+
+        @Override
+        protected void setup(final ModelControllerClient modelControllerClient) throws Exception {
+            if (WORK_DIR.exists()) {
+                FileUtils.deleteDirectory(WORK_DIR);
+            }
+            WORK_DIR.mkdirs();
+            super.setup(modelControllerClient);
+        }
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            return new ConfigurableElement[] {
+                    SimpleKeyStore.builder().withName(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                            .withPath(Path.builder().withPath(SERVER_KEYSTORE_FILE.getAbsolutePath()).build())
+                            .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                            .withType("PKCS12")
+                            .build(),
+                    SimpleKeyManager.builder().withName(NAME)
+                            .withKeyStore(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                            .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                            .withGenerateSelfSignedCertificateHost(GENERATE_SELF_SIGNED_CERTIFICATE_HOST)
+                            .build(),
+                    SimpleServerSslContext.builder().withName(NAME)
+                            .withKeyManagers(NAME)
+                            .build(),
+                    UndertowSslContext.builder().withName(NAME).build()
+            };
+        }
+
+        @Override
+        protected void tearDown(ModelControllerClient modelControllerClient) throws Exception {
+            super.tearDown(modelControllerClient);
+            FileUtils.deleteDirectory(WORK_DIR);
+        }
+    }
+
+    private void closeClient(HttpClient client) {
+        try {
+            ((CloseableHttpClient) client).close();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to close HTTP client", ex);
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/AutomaticSelfSignedCertificateNotGeneratedTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/AutomaticSelfSignedCertificateNotGeneratedTestCase.java
@@ -1,0 +1,227 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.ssl;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.jboss.as.test.integration.security.common.SSLTruststoreUtil.HTTPS_PORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.codehaus.plexus.util.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.SSLTruststoreUtil;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.Path;
+import org.wildfly.test.security.common.elytron.SimpleKeyManager;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.UndertowSslContext;
+
+/**
+ * Test that a self-signed certificate is not automatically generated if the keystore
+ * file already exists.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ AutomaticSelfSignedCertificateNotGeneratedTestCase.ElytronAndUndertowSetupTask.class })
+@RunAsClient
+@Category(CommonCriteria.class)
+public class AutomaticSelfSignedCertificateNotGeneratedTestCase {
+
+    private static final String NAME = AutomaticSelfSignedCertificateNotGeneratedTestCase.class.getSimpleName();
+    private static final File WORK_DIR = new File("target" + File.separatorChar +  NAME);
+    private static final File SERVER_KEYSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.SERVER_KEYSTORE);
+    private static final File CLIENT_TRUSTSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.CLIENT_TRUSTSTORE);
+    private static final String PASSWORD = SecurityTestConstants.KEYSTORE_PASSWORD;
+    private static final String GENERATE_SELF_SIGNED_CERTIFICATE_HOST="customHostName";
+    private static final String SERVER_ALIAS = "server";
+    private static final String EXISTING_HOST = "existingHost";
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war").addClasses(SimpleServlet.class);
+    }
+
+    @Test
+    public void testSelfSignedCertificateNotGeneratedIfKeyStoreFileExists() throws Exception {
+        assertTrue(SERVER_KEYSTORE_FILE.exists());
+        assertTrue(CLIENT_TRUSTSTORE_FILE.exists());
+
+        final URL servletUrl = new URL("https", TestSuiteEnvironment.getServerAddress(), HTTPS_PORT,
+                "/" + NAME + "/" + SimpleServlet.SERVLET_PATH.substring(1));
+        HttpClient client = SSLTruststoreUtil.getHttpClientWithSSL(CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        try {
+            Utils.makeCallWithHttpClient(servletUrl, client, SC_OK);
+            try (FileInputStream is = new FileInputStream(SERVER_KEYSTORE_FILE.getAbsolutePath())) {
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                keyStore.load(is, PASSWORD.toCharArray());
+                assertEquals(1, keyStore.size());
+                X509Certificate serverCert = (X509Certificate) keyStore.getCertificate(SERVER_ALIAS);
+                assertEquals("CN=" + EXISTING_HOST, serverCert.getSubjectX500Principal().getName());
+            }
+        } catch (IOException | URISyntaxException ex) {
+            throw new IllegalStateException("Unable to request server root over HTTPS", ex);
+        } finally {
+            closeClient(client);
+        }
+    }
+
+    @Test
+    public void testSelfSignedCertificateNotGeneratedWithGenerateAttributeUndefined() throws Exception {
+        // undefine generate-self-signed-certificate-host
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:undefine-attribute(name=generate-self-signed-certificate-host)",
+                    NAME));
+            cli.sendLine(String.format("reload"));
+        }
+        try {
+            assertTrue(SERVER_KEYSTORE_FILE.exists());
+            assertTrue(CLIENT_TRUSTSTORE_FILE.exists());
+
+            final URL servletUrl = new URL("https", TestSuiteEnvironment.getServerAddress(), HTTPS_PORT,
+                    "/" + NAME + "/" + SimpleServlet.SERVLET_PATH.substring(1));
+            HttpClient client = SSLTruststoreUtil.getHttpClientWithSSL(CLIENT_TRUSTSTORE_FILE, PASSWORD);
+            try {
+                Utils.makeCallWithHttpClient(servletUrl, client, SC_OK);
+                try (FileInputStream is = new FileInputStream(SERVER_KEYSTORE_FILE.getAbsolutePath())) {
+                    KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                    keyStore.load(is, PASSWORD.toCharArray());
+                    assertEquals(1, keyStore.size());
+                    X509Certificate serverCert = (X509Certificate) keyStore.getCertificate(SERVER_ALIAS);
+                    assertEquals("CN=" + EXISTING_HOST, serverCert.getSubjectX500Principal().getName());
+                }
+            } catch (IOException | URISyntaxException ex) {
+                throw new IllegalStateException("Unable to request server root over HTTPS", ex);
+            } finally {
+                closeClient(client);
+            }
+        } finally {
+            // clean up
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:write-attribute(name=generate-self-signed-certificate-host,value=%s)",
+                        NAME, GENERATE_SELF_SIGNED_CERTIFICATE_HOST));
+                cli.sendLine(String.format("reload"));
+            }
+        }
+    }
+
+    static class ElytronAndUndertowSetupTask extends AbstractElytronSetupTask {
+
+        @Override
+        protected void setup(final ModelControllerClient modelControllerClient) throws Exception {
+            createServerKeyStoreAndClientTrustStore();
+            super.setup(modelControllerClient);
+        }
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            return new ConfigurableElement[] {
+                    SimpleKeyStore.builder().withName(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                            .withPath(Path.builder().withPath(SERVER_KEYSTORE_FILE.getAbsolutePath()).build())
+                            .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                            .withType("PKCS12")
+                            .build(),
+                    SimpleKeyManager.builder().withName(NAME)
+                            .withKeyStore(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                            .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                            .withGenerateSelfSignedCertificateHost(GENERATE_SELF_SIGNED_CERTIFICATE_HOST)
+                            .build(),
+                    SimpleServerSslContext.builder().withName(NAME)
+                            .withKeyManagers(NAME)
+                            .build(),
+                    UndertowSslContext.builder().withName(NAME).build()
+            };
+        }
+
+        @Override
+        protected void tearDown(ModelControllerClient modelControllerClient) throws Exception {
+            super.tearDown(modelControllerClient);
+            FileUtils.deleteDirectory(WORK_DIR);
+        }
+
+        private void createServerKeyStoreAndClientTrustStore() throws Exception {
+            if (WORK_DIR.exists()) {
+                FileUtils.deleteDirectory(WORK_DIR);
+            }
+            WORK_DIR.mkdirs();
+            KeyStore ks = KeyStore.getInstance("PKCS12");
+            ks.load(null, null);
+            SelfSignedX509CertificateAndSigningKey selfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
+                    .setDn(new X500Principal("CN=existingHost"))
+                    .build();
+            PrivateKey privateKey = selfSignedX509CertificateAndSigningKey.getSigningKey();
+            X509Certificate serverCert = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
+            ks.setKeyEntry("server", privateKey, PASSWORD.toCharArray(), new X509Certificate[]{ serverCert });
+            try (FileOutputStream fos = new FileOutputStream(SERVER_KEYSTORE_FILE)) {
+                ks.store(fos, PASSWORD.toCharArray());
+            }
+            try (FileOutputStream fos = new FileOutputStream(CLIENT_TRUSTSTORE_FILE)) {
+                KeyStore trustStore = KeyStore.getInstance("PKCS12");
+                trustStore.load(null, null);
+                trustStore.setCertificateEntry("server", serverCert);
+                trustStore.store(fos, PASSWORD.toCharArray());
+            }
+        }
+    }
+
+    private void closeClient(HttpClient client) {
+        try {
+            ((CloseableHttpClient) client).close();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to close HTTP client", ex);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleKeyManager.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleKeyManager.java
@@ -38,19 +38,26 @@ public class SimpleKeyManager extends AbstractConfigurableElement implements Key
 
     private final String keyStore;
     private final CredentialReference credentialReference;
+    private final String generateSelfSignedCertificateHost;
 
     private SimpleKeyManager(Builder builder) {
         super(builder);
         this.keyStore = Objects.requireNonNull(builder.keyStore, "Key-store name has to be provided");
         this.credentialReference = defaultIfNull(builder.credentialReference, CredentialReference.EMPTY);
+        this.generateSelfSignedCertificateHost = builder.generateSelfSignedCertificateHost;
     }
 
     @Override
     public void create(CLIWrapper cli) throws Exception {
         // /subsystem=elytron/key-manager=httpsKM:add(key-store=httpsKS,algorithm="SunX509",credential-reference={clear-text=secret})
 
-        cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:add(key-store=\"%s\",algorithm=\"%s\", %s)", name,
-                keyStore, KeyManagerFactory.getDefaultAlgorithm(), credentialReference.asString()));
+        if (generateSelfSignedCertificateHost != null) {
+            cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:add(key-store=\"%s\",algorithm=\"%s\", %s,generate-self-signed-certificate-host=\"%s\")", name,
+                    keyStore, KeyManagerFactory.getDefaultAlgorithm(), credentialReference.asString(), generateSelfSignedCertificateHost));
+        } else {
+            cli.sendLine(String.format("/subsystem=elytron/key-manager=%s:add(key-store=\"%s\",algorithm=\"%s\", %s)", name,
+                    keyStore, KeyManagerFactory.getDefaultAlgorithm(), credentialReference.asString()));
+        }
     }
 
     @Override
@@ -73,6 +80,7 @@ public class SimpleKeyManager extends AbstractConfigurableElement implements Key
     public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
         private String keyStore;
         private CredentialReference credentialReference;
+        private String generateSelfSignedCertificateHost;
 
         private Builder() {
         }
@@ -84,6 +92,11 @@ public class SimpleKeyManager extends AbstractConfigurableElement implements Key
 
         public Builder withCredentialReference(CredentialReference credentialReference) {
             this.credentialReference = credentialReference;
+            return this;
+        }
+
+        public Builder withGenerateSelfSignedCertificateHost(String generateSelfSignedCertificateHost) {
+            this.generateSelfSignedCertificateHost = generateSelfSignedCertificateHost;
             return this;
         }
 

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
@@ -87,6 +87,7 @@ public class XTSSubsystemDefinition extends SimpleResourceDefinition {
                 XTSExtension.getResourceDescriptionResolver(null),
                 XTSSubsystemAdd.INSTANCE,
                 XTSSubsystemRemove.INSTANCE);
+        setDeprecated(ModelVersion.create(3,0,0));
     }
 
     /**

--- a/xts/src/main/resources/org/jboss/as/xts/LocalDescriptions.properties
+++ b/xts/src/main/resources/org/jboss/as/xts/LocalDescriptions.properties
@@ -35,3 +35,5 @@ xts.url=If set configures a remote coordinator service to be used when an XTS cl
 xts.default-context-propagation=Automatically sets up client side handlers.
 
 xts.async-registration=Initialize endpoints for asynchronous registration needed for WS-AT .NET integration.
+
+xts.deprecated=Deprecated since the XTS feature set is rarely used and is considered legacy within development approaches nowadays.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-14025

This PR added tests to verify the fix.

Test cases are:

* @Resource() DataSource ds; injection without name and lookup
* @Resource(name="ds") DataSource ds; injection with name specified
* @Resource(name="ds") DataSource ds; injection with name specified, and lookup is specified in jboss-web.xml
* @Resource(name="ds") DataSource ds; simulates injection done in ServletContextListener
